### PR TITLE
chore: update compatibilityDate to 2026-06-30

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
     }
   },
 
-  compatibilityDate: '2025-01-15',
+  compatibilityDate: '2026-06-30',
 
   hub: {
     blob: true


### PR DESCRIPTION
Updates the Nuxt `compatibilityDate` to today's date (2026-06-30).